### PR TITLE
Update to Avalonia 11.2.0

### DIFF
--- a/Avalonia.MusicStore/Avalonia.MusicStore.csproj
+++ b/Avalonia.MusicStore/Avalonia.MusicStore.csproj
@@ -18,12 +18,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.9" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.9" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.9" />
+    <PackageReference Include="Avalonia" Version="11.2.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.2.0" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.0" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.9" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.9" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.0" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.2.0" />
     <PackageReference Include="iTunesSearch" Version="1.0.44" />
   </ItemGroup>
 </Project>

--- a/Avalonia.MusicStore/Views/MainWindow.axaml.cs
+++ b/Avalonia.MusicStore/Views/MainWindow.axaml.cs
@@ -18,7 +18,7 @@ namespace Avalonia.MusicStore.Views
                 action(ViewModel!.ShowDialog.RegisterHandler(DoShowDialogAsync)));
         }
 
-        private async Task DoShowDialogAsync(InteractionContext<MusicStoreViewModel,
+        private async Task DoShowDialogAsync(IInteractionContext<MusicStoreViewModel,
                                                 AlbumViewModel?> interaction)
         {
             var dialog = new MusicStoreWindow();


### PR DESCRIPTION
Updating to 11.2 appears to require a change to the method signature for registering interaction handlers.